### PR TITLE
Add SE_SIGNING_LEVEL_ANTIMALWARE for MsMpEng.exe

### DIFF
--- a/PPLKiller/main.cpp
+++ b/PPLKiller/main.cpp
@@ -367,6 +367,7 @@ FindSignatureLevelOffsets(
 
 						if ((CandidateSignatureLevel == SE_SIGNING_LEVEL_MICROSOFT ||
 							CandidateSignatureLevel == SE_SIGNING_LEVEL_WINDOWS ||
+							CandidateSignatureLevel == SE_SIGNING_LEVEL_ANTIMALWARE ||
 							CandidateSignatureLevel == SE_SIGNING_LEVEL_WINDOWS_TCB)
 							&&
 							(CandidateSectionSignatureLevel == SE_SIGNING_LEVEL_MICROSOFT ||
@@ -527,6 +528,7 @@ UnprotectProcesses(
 
 				if ((SignatureLevel == SE_SIGNING_LEVEL_MICROSOFT ||
 					SignatureLevel == SE_SIGNING_LEVEL_WINDOWS ||
+					SignatureLevel == SE_SIGNING_LEVEL_ANTIMALWARE ||
 					SignatureLevel == SE_SIGNING_LEVEL_WINDOWS_TCB)
 					&&
 					(SectionSignatureLevel == SE_SIGNING_LEVEL_MICROSOFT ||


### PR DESCRIPTION
It seems that in Windows 10 1709 (= Fall Creators Update), MsMpEng.exe is running with `SE_SIGNING_LEVEL_ANTIMALWARE`.  Need to check this flag to get 100% match count.